### PR TITLE
Update nav so that ppbl2024-front-end nav does not point to a 404 

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -114,7 +114,9 @@ export default function Navigation() {
               >
                 Text and video content
               </ListItem>
-              <ListItem href="/live-examples" title="Project-Based Learning">
+                <ListItem
+                  href="/live-examples"
+                  title="Project-Based Learning">
                 Get hands on experience as a Cardano developer
               </ListItem>
               <ListItem href="https://gimbalabs.com" title="From Gimbalabs">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -114,9 +114,10 @@ export default function Navigation() {
               >
                 Text and video content
               </ListItem>
-                <ListItem
-                  href="/live-examples"
-                  title="Project-Based Learning">
+              <ListItem
+                href="/live-examples"
+                title="Project-Based Learning"
+              >
                 Get hands on experience as a Cardano developer
               </ListItem>
               <ListItem href="https://gimbalabs.com" title="From Gimbalabs">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -97,7 +97,7 @@ export default function Navigation() {
                 <NavigationMenuLink asChild>
                   <a
                     className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
-                    href="https://andamio.io/course/ppbl2024"
+                    href="https://app.andamio.io/course/ppbl2024"
                   >
                     <div className="mb-2 mt-4 text-lg font-medium">
                       Plutus PBL 2024
@@ -109,15 +109,12 @@ export default function Navigation() {
                 </NavigationMenuLink>
               </li>
               <ListItem
-                href="https://andamio.io/course/ppbl2024"
+                href="https://app.andamio.io/course/ppbl2024"
                 title="Take the Course"
               >
                 Text and video content
               </ListItem>
-              <ListItem
-                href="/live-examples"
-                title="Project-Based Learning"
-              >
+              <ListItem href="/live-examples" title="Project-Based Learning">
                 Get hands on experience as a Cardano developer
               </ListItem>
               <ListItem href="https://gimbalabs.com" title="From Gimbalabs">
@@ -181,7 +178,6 @@ export default function Navigation() {
             </NavigationMenuLink>
           </Link>
         </NavigationMenuItem>
-       
       </NavigationMenuList>
     </NavigationMenu>
   );


### PR DESCRIPTION
Currently this points to a 404 page. 
It should point to the actual ppbl course. 